### PR TITLE
added Dot damage

### DIFF
--- a/Assets/Items/BurnObstacle.asset
+++ b/Assets/Items/BurnObstacle.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ad608494c5cf46eaa2a0818b16b022d, type: 3}
+  m_Name: BurnObstacle
+  m_EditorClassIdentifier: 
+  itemName: Burn
+  thumbnail: {fileID: 0}
+  prefab: {fileID: 0}
+  effectAsset: {fileID: 11400000, guid: 7538a78ca43281d48bc3e1b28393264f, type: 2}

--- a/Assets/Items/BurnObstacle.asset.meta
+++ b/Assets/Items/BurnObstacle.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b708a0c9ab8fe849a438d2b601d2c24
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -746,6 +746,8 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   invincibleDuration: 0
+  shieldDuration: 0
+  damageReductionFactor: 0
 --- !u!1 &392905340
 GameObject:
   m_ObjectHideFlags: 0
@@ -1234,6 +1236,8 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   invincibleDuration: 0
+  shieldDuration: 0
+  damageReductionFactor: 0
 --- !u!1 &587867125
 GameObject:
   m_ObjectHideFlags: 0
@@ -2118,6 +2122,8 @@ GameObject:
   - component: {fileID: 1066880255}
   - component: {fileID: 1066880254}
   - component: {fileID: 1066880253}
+  - component: {fileID: 1066880258}
+  - component: {fileID: 1066880257}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -2189,6 +2195,42 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1066880257
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1066880252}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1befe4496c90408ca72e4adaccb9edc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxHealth: 100
+  OnHealthChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  invincibleDuration: 0
+  shieldDuration: 0
+  damageReductionFactor: 0
+--- !u!114 &1066880258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1066880252}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5a7b2b642e0ed334ca3c79772a472650, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxStamina: 1000
+  recoveryRate: 10
+  OnStaminaChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1001 &1080670004
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PlayerMovementScene.unity
+++ b/Assets/Scenes/PlayerMovementScene.unity
@@ -3478,7 +3478,7 @@ MonoBehaviour:
     prefab: {fileID: 1162461597}
   - type: 2
     prefab: {fileID: 2099841012}
-  mapFileName: TestMap
+  mapFileName: Stage1
 --- !u!4 &858783386
 Transform:
   m_ObjectHideFlags: 0
@@ -4954,6 +4954,117 @@ Transform:
   m_Father: {fileID: 2002015694}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1685675852
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1685675857}
+  - component: {fileID: 1685675856}
+  - component: {fileID: 1685675855}
+  - component: {fileID: 1685675854}
+  - component: {fileID: 1685675853}
+  m_Layer: 0
+  m_Name: Obs
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1685675853
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1685675852}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9f39867bdd86a4631aa230b60bf02c89, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  itemData: {fileID: 11400000, guid: 8b708a0c9ab8fe849a438d2b601d2c24, type: 2}
+--- !u!65 &1685675854
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1685675852}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1685675855
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1685675852}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1685675856
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1685675852}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1685675857
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1685675852}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 11.3, y: 4.8, z: 147.90306}
+  m_LocalScale: {x: 10, y: 10, z: 10}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1702744876
 GameObject:
   m_ObjectHideFlags: 0
@@ -5726,7 +5837,7 @@ GameObject:
   - component: {fileID: 1992866919}
   m_Layer: 0
   m_Name: Player
-  m_TagString: Untagged
+  m_TagString: Player
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -5990,6 +6101,10 @@ PrefabInstance:
     - target: {fileID: 391372174857379828, guid: 6e4a7c5504829eb4eb03130d798e9f7f, type: 3}
       propertyPath: m_Name
       value: ChunkContainer
+      objectReference: {fileID: 0}
+    - target: {fileID: 391372174857379828, guid: 6e4a7c5504829eb4eb03130d798e9f7f, type: 3}
+      propertyPath: m_TagString
+      value: Untagged
       objectReference: {fileID: 0}
     - target: {fileID: 7416310173404884990, guid: 6e4a7c5504829eb4eb03130d798e9f7f, type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Scripts/Effects/Burn Dot Damage Effect.asset
+++ b/Assets/Scripts/Effects/Burn Dot Damage Effect.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2c0bad45cba160041abedcb569ef08f8, type: 3}
+  m_Name: Burn Dot Damage Effect
+  m_EditorClassIdentifier: 
+  dotDamage: 3
+  interval: 1
+  ticks: 10

--- a/Assets/Scripts/Effects/Burn Dot Damage Effect.asset.meta
+++ b/Assets/Scripts/Effects/Burn Dot Damage Effect.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7538a78ca43281d48bc3e1b28393264f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Effects/DotDamageEffect.cs
+++ b/Assets/Scripts/Effects/DotDamageEffect.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Effect/Dot Damage")]
+public class DotDamageEffect : ScriptableObject, IEffect
+{
+    [SerializeField] protected int dotDamage = 3;
+    [SerializeField] protected float interval = 1f;
+    [SerializeField] protected int ticks = 10;
+
+    public void Apply(GameObject player)
+    {
+        if (player.TryGetComponent<PlayerMovement>(out var mono))
+        {
+            mono.StartCoroutine(ApplyDotDamage(player, interval, ticks));
+        }
+        else
+        {
+            Debug.LogWarning($"[DotDamageEffect] {player.name}에 PlayerMovement 컴포넌트가 없습니다!");
+            return;
+        }
+    }
+
+    IEnumerator ApplyDotDamage(GameObject player, float interval, int ticks)
+    {
+        if (player.TryGetComponent<Health>(out var health))
+        {
+            for(int i=0;i<ticks;i++)
+            {
+                health.ChangeHealth(dotDamage);
+                Debug.Log($"[DotDamageEffect] {player.name}에게 {dotDamage}의 지속 피해를 입혔습니다. 남은 체력: {health.CurrentHealth}");
+                yield return new WaitForSeconds(interval);
+            }
+        }
+        else
+        {
+            Debug.LogWarning($"[DotDamageEffect] {player.name}에 Health 컴포넌트가 없습니다!");
+        }
+    }
+}

--- a/Assets/Scripts/Effects/DotDamageEffect.cs.meta
+++ b/Assets/Scripts/Effects/DotDamageEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2c0bad45cba160041abedcb569ef08f8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Stamina.cs
+++ b/Assets/Scripts/Stamina.cs
@@ -6,7 +6,7 @@ using System.Collections;
 [DisallowMultipleComponent]
 public class Stamina : MonoBehaviour
 {
-    [SerializeField] int maxStamina = 100000;
+    [SerializeField] int maxStamina = 1000;
     [SerializeField] float recoveryRate = 10f; // 초당 회복량
 
     private int currentStamina;
@@ -29,7 +29,7 @@ public class Stamina : MonoBehaviour
         // {
         //     RecoverStamina();
         // }
-        Debug.Log("Current Stamina : " + currentStamina + "/" + maxStamina);
+        // Debug.Log("Current Stamina : " + currentStamina + "/" + maxStamina);
     }
 
     public bool IsStaminaAvailable()


### PR DESCRIPTION
# PR Title [Dot Damage]
## PR Description
닿으면 피를 일정 횟수에 걸쳐 여러 번 깎는 도트 데미지 Effect를 구현했습니다.
(그리고 GameScene의 Player 오브젝트에 Health.cs, Stamina.cs 컴포넌트가 없어서 추가했습니다)
### Changes Included
- [x] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation
### Screenshots (if UI changes were made)
Attach screenshots or GIFs of any visual changes. (Only for frontend-related changes)
### Notes for Reviewer
Any specific instructions or points to be considered by the reviewer.
---
## Reviewer Checklist
- [x] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [x] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.
---
## Additional Comments
아이템 형태로 구현했으므로 장애물에 ItemPickup 컴포넌트를 추가하면 됩니다. PlayerMovementScene에서 테스트하였습니다.
